### PR TITLE
Adds boresch analytical restraint + colinear restrictions

### DIFF
--- a/MDRestraintsGenerator/restraints.py
+++ b/MDRestraintsGenerator/restraints.py
@@ -123,9 +123,18 @@ class FindBoreschRestraint(AnalysisBase):
 
         # Rank restraints based on how much they fluctuate
         # Assign the best restraint
-        var_list = [restraint.varsum for restraint in self._restraints]
+        # Note: to avoid co-linearity we drop anything where the mean angles
+        # are < 25 or > 155 degrees (assign it a var of over 9 thousand)
+        var_list = []
+
+        for restraint in self._restraints:
+            var = restraint.varsum
+            for angle in restraint.angles:
+                if angle.mean < 25 or angle.mean > 155:
+                    var += 9000
+            var_list.append(var)
+
         self.restraint = self._restraints[var_list.index(min(var_list))]
 
         # Get rmsd & populate min frame/rmsd
         self.restraint.rmsd()
-

--- a/MDRestraintsGenerator/tests/test_FindBoreschRestraint.py
+++ b/MDRestraintsGenerator/tests/test_FindBoreschRestraint.py
@@ -25,10 +25,11 @@ def test_basic_regression(tmpdir, u):
         find.run()
 
         find.restraint.write()
+        dG = find.restraint.standard_state()
         
         u_gro = mda.Universe('ClosestRestraintFrame.gro')
         u_gro_ref = mda.Universe(T4_OGRO)
 
         assert_almost_equal(u_gro.atoms.positions, u_gro_ref.atoms.positions)
         assert filecmp.cmp(T4_OTOP, 'BoreschRestraint.top')
-
+        assert_almost_equal(dG, -6.592, 2)

--- a/MDRestraintsGenerator/tests/test_datatypes.py
+++ b/MDRestraintsGenerator/tests/test_datatypes.py
@@ -72,3 +72,27 @@ def test_Boresch_plotting_notanalysed(tmpdir, u):
 
     with pytest.raises(AttributeError, match=errmsg):
         boresch.plot()
+
+
+def test_Boresch_write_noframe(u):
+    l_atoms = [0, 1, 2]
+    p_atoms = [4, 5, 6]
+
+    boresch = dtypes.BoreschRestraint(u, l_atoms, p_atoms)
+
+    errmsg = "no frame defined for writing"
+
+    with pytest.raises(RuntimeError, match=errmsg):
+        boresch.write()
+
+
+def test_Boresch_write_wrongtype(u):
+    l_atoms = [0, 1, 2]
+    p_atoms = [4, 5, 6]
+
+    boresch = dtypes.BoreschRestraint(u, l_atoms, p_atoms)
+
+    errmsg = "not implemented yet"
+
+    with pytest.raises(RuntimeError, match=errmsg):
+        boresch.write(frame=0, outtype="AMBER")

--- a/scripts/BoreschRestraintGMX.py
+++ b/scripts/BoreschRestraintGMX.py
@@ -57,3 +57,9 @@ if __name__ == "__main__":
 
     # Write out the intermolecular section to a topology
     boresch.restraint.write()
+
+    dG_off = boresch.restraint.standard_state()
+
+    print(f"dG_off: {dG_off}, dG_on: {-dG_off}")
+
+


### PR DESCRIPTION
Fixes #7 

Adds in an option to get analytical restraint dG_off.
Also adds in restrictions in the angles (can't be < 25 or > 155 degrees) to avoid co-linear restraints.

Note: in practice after ~ 60 systems, I've never hit an angle that was < 25 or > 155 degrees.