### PR TITLE
Adds protein search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - CYTHON_TRACE_NOGIL=1
     - MPLBACKEND=agg
       # scipy and matplotlib are in MDAnalysis
-    - CONDA_DEPENDENCIES="numpy==1.17 MDAnalysis MDAnalysisTests pytest pytest-cov codecov"
+    - CONDA_DEPENDENCIES="numpy==1.18.5 MDAnalysis MDAnalysisTests pytest pytest-cov codecov"
     - CONDA_CHANNELS='conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - CYTHON_TRACE_NOGIL=1
     - MPLBACKEND=agg
       # scipy and matplotlib are in MDAnalysis
-    - CONDA_DEPENDENCIES="MDAnalysis MDAnalysisTests pytest pytest-cov codecov"
+    - CONDA_DEPENDENCIES="numpy==1.18.5 MDAnalysis MDAnalysisTests pytest pytest-cov codecov"
     - CONDA_CHANNELS='conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
 
 install:
   - conda create --yes -n test python=$PYTHON_VERSION
-  - conda install --yes -n test numpy==1.18 MDAnalysis MDAnalysisTests pytest pytest-cov codecov -c conda-forge
+  - conda install --yes -n test numpy==1.18.5 MDAnalysis MDAnalysisTests pytest pytest-cov codecov -c conda-forge
   - conda activate test
   - python -V
     # Build and install package

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
 
 
 install:
-  - conda create -n test python=$PYTHON_VERSION
+  - conda create --yes -n test python=$PYTHON_VERSION
   - conda install --yes -n test numpy==1.18 MDAnalysis MDAnalysisTests pytest pytest-cov codecov -c conda-forge
   - conda activate test
   - python -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
 
 
 install:
-  - conda env create -n test python=$PYTHON_VERSION
+  - conda create -n test python=$PYTHON_VERSION
   - conda install --yes -n test numpy==1.18 MDAnalysis MDAnalysisTests pytest pytest-cov codecov -c conda-forge
   - conda activate test
   - python -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - CYTHON_TRACE_NOGIL=1
     - MPLBACKEND=agg
       # scipy and matplotlib are in MDAnalysis
-    - CONDA_DEPENDENCIES="numpy==1.18.5 MDAnalysis MDAnalysisTests pytest pytest-cov codecov"
+    - CONDA_DEPENDENCIES="numpy==1.17 MDAnalysis MDAnalysisTests pytest pytest-cov codecov"
     - CONDA_CHANNELS='conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,25 @@ before_install:
   - uname -a
   - df -h
   - ulimit -a
+  # get the right anaconda version
+  - |
+     if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+       wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
+     else
+       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+     fi
+  - mkdir $HOME/.conda
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - $HOME/miniconda/bin/conda init bash
+  - source ~/.bash_profile
+  - conda activate base
+  - conda update --yes conda
 
 
 install:
-
-    # Create test environment for package (using astropy's ci-helper)
-  - git clone git://github.com/astropy/ci-helpers.git
-  - source ci-helpers/travis/setup_conda.sh
+  - conda env create -n test python=$PYTHON_VERSION
+  - conda install --yes -n test numpy==1.18 MDAnalysis MDAnalysisTests pytest pytest-cov codecov -c conda-forge
+  - conda activate test
   - python -V
     # Build and install package
   - python setup.py develop --no-deps

--- a/MDRestraintsGenerator/datatypes.py
+++ b/MDRestraintsGenerator/datatypes.py
@@ -19,7 +19,6 @@ import MDAnalysis as mda
 import numpy as np
 from scipy import stats
 from scipy.stats import circmean, circvar, circstd
-import matplotlib as mpl
 from matplotlib import pyplot as plt
 
 
@@ -95,13 +94,10 @@ class VectorData:
                 bin_width = 4
                 return np.arange(-180, 180 + bin_width, bin_width)
 
-
         try:
             self.mean
         except AttributeError:
             raise AttributeError("vector object has not been analyzed yet")
-
-
 
         # Set some parameters and prep figure
         pltparams = {'font.size': 12,
@@ -262,7 +258,7 @@ class BoreschRestraint:
             Indices of the protein atoms.
         n_frames : int [`None`]
             Number of frames to store data for.
-        
+
         Note
         ----
         Bond is defined by (l_atoms[0], p_atoms[0])
@@ -477,7 +473,6 @@ class BoreschRestraint:
             except AttributeError:
                 raise RuntimeError("no frame defined to get energy for")
 
-
         if calc_type != "analytical":
             raise NotImplementedError(f"{calc_type} is not implemented")
         else:
@@ -495,10 +490,10 @@ class BoreschRestraint:
         -----
         This is known to be inaccurate (see Yank).
         """
-        Gas_K = (8.314472*0.001) / 4.184 # Gas constant kcal/mol/K
-        StandardV = 1.66 # standard volume in nm^3
+        Gas_K = (8.314472*0.001) / 4.184  # Gas constant kcal/mol/K
+        StandardV = 1.66  # standard volume in nm^3
 
-        rAa = self.bond.values[frame] / 10 # convert to nm
+        rAa = self.bond.values[frame] / 10  # convert to nm
         thA = np.radians(self.angles[0].values[frame])
         thB = np.radians(self.angles[1].values[frame])
 
@@ -508,10 +503,9 @@ class BoreschRestraint:
 
         numerator = 8.0 * (np.pi**2) * StandardV
         numerator *= ((frc_bond * (frc_angle ** 2) * (frc_dihe ** 3)) ** 0.5)
-        denominator = (rAa **2) * np.sin(thA) * np.sin(thB)
+        denominator = (rAa ** 2) * np.sin(thA) * np.sin(thB)
         denominator *= ((2 * np.pi * Gas_K * temperature) ** 3)
 
         dG = - Gas_K * temperature * np.log(numerator/denominator)
 
         return dG
-

--- a/MDRestraintsGenerator/datatypes.py
+++ b/MDRestraintsGenerator/datatypes.py
@@ -414,7 +414,7 @@ class BoreschRestraint:
             except AttributeError:
                 raise RuntimeError("no frame defined for writing")
 
-        if outtype is not "GMX":
+        if outtype != "GMX":
             raise RuntimeError(f"{outtype} not implemented yet")
 
         # Final check for co-linearity
@@ -478,7 +478,7 @@ class BoreschRestraint:
                 raise RuntimeError("no frame defined to get energy for")
 
 
-        if calc_type is not "analytical":
+        if calc_type != "analytical":
             raise NotImplementedError(f"{calc_type} is not implemented")
         else:
             return self._analytical_energy(frame, force_constant, temperature)

--- a/MDRestraintsGenerator/restraints.py
+++ b/MDRestraintsGenerator/restraints.py
@@ -5,11 +5,8 @@ A framework for generating restraints for MD simulations
 Contains main restraint object classes
 """
 
-import MDAnalysis as mda
 from MDAnalysis.analysis.base import AnalysisBase
 from .datatypes import BoreschRestraint
-import numpy as np
-import warnings
 
 
 class FindBoreschRestraint(AnalysisBase):

--- a/MDRestraintsGenerator/search.py
+++ b/MDRestraintsGenerator/search.py
@@ -235,9 +235,10 @@ class FindHostAtoms(AnalysisBase):
                             f"to {cutoff_distance}")
                     warnings.warn(wmsg)
                 else:
-                    wmsg= (f"Too few anchor atoms found, carrying on with "
-                           f"{found_atoms} anchors")
+                    wmsg = (f"Too few anchor atoms found, carrying on with "
+                            f"{found_atoms} anchors")
                     warnings.warn(wmsg)
+                    break
 
         for entry in anchors:
             if self.protein_routine and (self.p_selection ==
@@ -392,9 +393,5 @@ def _get_ligand_atoms_rmsf(atomgroup, l_selection, num_restraints, p_align):
                 angle_list.append((ixlist, score))
         angle_list.sort(key=lambda x: x[1])
         l_atoms.append(angle_list[0][0])
-
-    del(copy_u)
-    del(aligner)
-    del(rmsfer)
 
     return l_atoms

--- a/MDRestraintsGenerator/tests/test_FindBoreschRestraint.py
+++ b/MDRestraintsGenerator/tests/test_FindBoreschRestraint.py
@@ -96,3 +96,36 @@ def test_basic_regression_ligand_search(u):
                  [2607, 2606, 1563, 1569])
     assert_equal(boresch.restraint.dihedrals[2].atomgroup.atoms.ix,
                  [2606, 1563, 1569, 1571])
+
+
+def test_basic_regression_ligand_protein_search(u):
+    """Regression test to check we get the same answer on a ligand search"""
+
+    ligand_atoms = search.find_ligand_atoms(u)
+
+    assert ligand_atoms == [[2606, 2607, 2609], [2604, 2605, 2603],
+                            [2607, 2606, 2608]]
+
+    atom_set = []
+
+    for l_atoms in ligand_atoms:
+        psearch = search.FindHostAtoms(u, l_atoms[0])
+        psearch.run()
+        atom_set.extend([(l_atoms, p) for p in psearch.host_atoms])
+
+    boresch = FindBoreschRestraint(u, atom_set)
+
+    boresch.run()
+
+    assert_equal(boresch.restraint.bond.atomgroup.atoms.ix,
+                 [2606, 1563])
+    assert_equal(boresch.restraint.angles[0].atomgroup.atoms.ix,
+                 [2607, 2606, 1563])
+    assert_equal(boresch.restraint.angles[1].atomgroup.atoms.ix,
+                 [2606, 1563, 1569])
+    assert_equal(boresch.restraint.dihedrals[0].atomgroup.atoms.ix,
+                 [2609, 2607, 2606, 1563])
+    assert_equal(boresch.restraint.dihedrals[1].atomgroup.atoms.ix,
+                 [2607, 2606, 1563, 1569])
+    assert_equal(boresch.restraint.dihedrals[2].atomgroup.atoms.ix,
+                 [2606, 1563, 1569, 1571])

--- a/MDRestraintsGenerator/tests/test_search.py
+++ b/MDRestraintsGenerator/tests/test_search.py
@@ -71,6 +71,8 @@ def test_bonded_errors(u, errmsg, exclusion_str):
 def test_find_atoms_regression(u):
     l_atoms = search.find_ligand_atoms(u)
 
+    # l_atoms = [[2606, 2607, 2609], [2604, 2605, 2603], [2607, 2606, 2608]]
+
     assert l_atoms == [[2606, 2607, 2609], [2604, 2605, 2603],
                        [2607, 2606, 2608]]
 
@@ -85,3 +87,11 @@ def test_find_atoms_empty_align_selection(u):
     errmsg = "no atoms matchin"
     with pytest.raises(RuntimeError, match=errmsg):
         l_atoms = search.find_ligand_atoms(u, p_align="protein and name X")
+
+
+def test_search_from_capped_err(u):
+    lig = u.select_atoms('resname LIG')
+    prot = u.atoms
+    errmsg = "too many reference atoms passed"
+    with pytest.raises(ValueError, match=errmsg):
+        search._search_from_capped(lig, prot, 1.0)

--- a/MDRestraintsGenerator/tests/test_search.py
+++ b/MDRestraintsGenerator/tests/test_search.py
@@ -7,7 +7,6 @@ import MDAnalysis as mda
 from MDRestraintsGenerator import search
 from .datafiles import T4_TPR, T4_XTC
 from numpy.testing import assert_almost_equal
-import warnings
 import pytest
 
 
@@ -29,6 +28,20 @@ def test_no_host_anchors(u):
                                  init_cutoff=1, max_cutoff=3)
 
 
+def test_no_host_anchors_findhostatoms(u):
+    """Throws a warning that too few anchors have been found"""
+
+    errmsg = "Too few anchor atoms found, carrying on with"
+
+    l_atom = 2611
+
+    psearch = search.FindHostAtoms(u, l_atom, search_init_cutoff=1,
+                                   search_max_cutoff=3)
+
+    with pytest.warns(UserWarning, match=errmsg):
+        psearch.run()
+
+
 def test_cutoff_warning(u):
     """Throws a warning that cutoff is expanding"""
 
@@ -42,12 +55,25 @@ def test_cutoff_warning(u):
                                  init_cutoff=5, max_cutoff=9)
 
 
+def test_cutoff_warning_findhostatoms(u):
+    """Throws a warning that cutoff is expanding"""
+
+    errmsg = "Too few anchor atoms found, expanding cutoff"
+
+    l_atom = 2611
+
+    psearch = search.FindHostAtoms(u, l_atom)
+
+    with pytest.warns(UserWarning, match=errmsg):
+        psearch.run()
+
+
 def test_basic_bonded(u):
     """Basic test for getting a bonded atom"""
 
     p_atom = 1322
     expected_second_atom = 1320
-    expected_third_atom = 1318 
+    expected_third_atom = 1318
 
     second_atom, third_atom = search._get_bonded_host_atoms(u, p_atom)
 
@@ -70,8 +96,6 @@ def test_bonded_errors(u, errmsg, exclusion_str):
 
 def test_find_atoms_regression(u):
     l_atoms = search.find_ligand_atoms(u)
-
-    # l_atoms = [[2606, 2607, 2609], [2604, 2605, 2603], [2607, 2606, 2608]]
 
     assert l_atoms == [[2606, 2607, 2609], [2604, 2605, 2603],
                        [2607, 2606, 2608]]

--- a/MDRestraintsGenerator/tests/test_search.py
+++ b/MDRestraintsGenerator/tests/test_search.py
@@ -68,6 +68,26 @@ def test_cutoff_warning_findhostatoms(u):
         psearch.run()
 
 
+def test_findhostatoms_names(u):
+    """Checks that the first, second, and third index belong to the right
+    atom types"""
+
+    l_atom = 2611
+
+    psearch = search.FindHostAtoms(u, l_atom)
+
+    psearch.run()
+
+    for atoms in psearch.host_atoms:
+        assert u.atoms[atoms[0]].name == "CA"
+        assert u.select_atoms(f'index {atoms[0]} and bonded index {atoms[1]}')
+        assert u.atoms[atoms[1]].name == "C"
+        selstring = (f'index {atoms[1]} and (bonded index {atoms[0]}) and '
+                     f'(bonded index {atoms[2]})')
+        assert u.select_atoms(selstring)
+        assert u.atoms[atoms[2]].name == "N"
+
+
 def test_basic_bonded(u):
     """Basic test for getting a bonded atom"""
 

--- a/MDRestraintsGenerator/writers.py
+++ b/MDRestraintsGenerator/writers.py
@@ -5,9 +5,6 @@ A framework for generating restraints for MD simulations
 This file contains IO functions.
 """
 
-import MDAnalysis as mda
-import warnings
-
 
 def _write_bond_header(rfile):
     """Helper function to write the bond intermolecular section"""
@@ -97,4 +94,3 @@ def _write_dihedral(dihedral, index, force_constant, rfile):
     val = dihedral.values[index]
     rfile.write(f"{atom1:>6}{atom2:>6}{atom3:>6}{atom4:>6}     2    "
                 f"{val:>6.3f}    0.0    {val:>6.3f}   {angle_fc:>6.2f}\n")
-


### PR DESCRIPTION
Supersedes #25 

Original PR message:

This should be really useful when dealing with docked ligands that are likely to move a lot during the initial MD simulation.

Contents:

  - Adds a new FindHostAtoms class (derived from MDA's AnalysisBase)
  - Old :func:find_host_atoms should now be considered deprecated. I'm keeping it around for short-term backwards compatibility.