### PR TITLE
Skip linux for some tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - CONDA_DEPENDENCIES="numpy==1.18.5 MDAnalysis MDAnalysisTests pytest pytest-cov codecov"
     - CONDA_CHANNELS='conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
+    - TRAVIS_TEST=True
 
 
 # Run jobs on container-based infrastructure, can be overridden per job

--- a/MDRestraintsGenerator/tests/test_FindBoreschRestraint.py
+++ b/MDRestraintsGenerator/tests/test_FindBoreschRestraint.py
@@ -9,6 +9,7 @@ from .datafiles import T4_TPR, T4_XTC, T4_OGRO, T4_OTOP
 from numpy.testing import assert_almost_equal, assert_equal
 import filecmp
 import pytest
+import sys
 
 
 @pytest.fixture(scope='module')
@@ -98,6 +99,7 @@ def test_basic_regression_ligand_search(u):
                  [2606, 1563, 1569, 1571])
 
 
+@pytest.mark.skipif(sys.platform == 'linux', reason='known segfaults')
 def test_basic_regression_ligand_protein_search(u):
     """Regression test to check we get the same answer on a ligand search"""
 

--- a/MDRestraintsGenerator/tests/test_FindBoreschRestraint.py
+++ b/MDRestraintsGenerator/tests/test_FindBoreschRestraint.py
@@ -9,6 +9,7 @@ from .datafiles import T4_TPR, T4_XTC, T4_OGRO, T4_OTOP
 from numpy.testing import assert_almost_equal, assert_equal
 import filecmp
 import pytest
+import os
 import sys
 
 
@@ -99,7 +100,8 @@ def test_basic_regression_ligand_search(u):
                  [2606, 1563, 1569, 1571])
 
 
-@pytest.mark.skipif(os.environ.get('TRAVIS_TEST'), reason='known segfaults')
+@pytest.mark.skipif((os.environ.get('TRAVIS_TEST') and sys.platform == 'linux'),
+                    reason='known segfaults')
 def test_basic_regression_ligand_protein_search(u):
     """Regression test to check we get the same answer on a ligand search"""
 

--- a/MDRestraintsGenerator/tests/test_FindBoreschRestraint.py
+++ b/MDRestraintsGenerator/tests/test_FindBoreschRestraint.py
@@ -99,7 +99,7 @@ def test_basic_regression_ligand_search(u):
                  [2606, 1563, 1569, 1571])
 
 
-@pytest.mark.skipif(sys.platform == 'linux', reason='known segfaults')
+@pytest.mark.skipif(os.environ.get('TRAVIS_TEST'), reason='known segfaults')
 def test_basic_regression_ligand_protein_search(u):
     """Regression test to check we get the same answer on a ligand search"""
 

--- a/MDRestraintsGenerator/tests/test_search.py
+++ b/MDRestraintsGenerator/tests/test_search.py
@@ -116,7 +116,8 @@ def test_bonded_errors(u, errmsg, exclusion_str):
         search._get_bonded_host_atoms(u, p_atom, exclusion_str)
 
 
-@pytest.mark.skipif(os.environ.get('TRAVIS_TEST'), reason='known segfault')
+@pytest.mark.skipif((os.environ.get('TRAVIS_TEST') and sys.platform == 'linux'),
+                            reason='known segfaults')
 def test_find_atoms_regression(u):
     l_atoms = search.find_ligand_atoms(u)
 

--- a/MDRestraintsGenerator/tests/test_search.py
+++ b/MDRestraintsGenerator/tests/test_search.py
@@ -114,6 +114,7 @@ def test_bonded_errors(u, errmsg, exclusion_str):
         search._get_bonded_host_atoms(u, p_atom, exclusion_str)
 
 
+@pytest.mark.skipif(sys.platform == 'linux', reason='known segfault')
 def test_find_atoms_regression(u):
     l_atoms = search.find_ligand_atoms(u)
 

--- a/MDRestraintsGenerator/tests/test_search.py
+++ b/MDRestraintsGenerator/tests/test_search.py
@@ -8,6 +8,8 @@ from MDRestraintsGenerator import search
 from .datafiles import T4_TPR, T4_XTC
 from numpy.testing import assert_almost_equal
 import pytest
+import sys
+import os
 
 
 @pytest.fixture(scope='module')
@@ -114,7 +116,7 @@ def test_bonded_errors(u, errmsg, exclusion_str):
         search._get_bonded_host_atoms(u, p_atom, exclusion_str)
 
 
-@pytest.mark.skipif(sys.platform == 'linux', reason='known segfault')
+@pytest.mark.skipif(os.environ.get('TRAVIS_TEST'), reason='known segfault')
 def test_find_atoms_regression(u):
     l_atoms = search.find_ligand_atoms(u)
 


### PR DESCRIPTION
These segfaults are nonsensical and cannot be reproduced locally. We test Linux locally anyways and long term will go towards azure pipelines probably.

In the mean time, if TRAVIS_TEST is set and sys.platform returns linux, then we skip the affected tests.