### PR TITLE
Adds box argument to capped_distance search

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,15 @@
+MDRestraints Generator CHANGELOG
+
+AUTHORS: IAlibay
+
+
+* 0.2.0 : ??/??/????
+
+Fixes
+  * capped_distance call in _search_capped now accounts for box dimensions
+    (PR #35)
+
+* 0.1.0 : 01/03/2021
+
+Changes
+  * Initial release, includes support for Boresch restraints.

--- a/MDRestraintsGenerator/search.py
+++ b/MDRestraintsGenerator/search.py
@@ -13,7 +13,7 @@ from MDAnalysis.lib.distances import capped_distance
 import warnings
 
 
-def _search_from_capped(ref_ag, config_ag, cutoff):
+def _search_from_capped(ref_ag, config_ag, universe, cutoff):
     """Helper function to search for neighbouring atoms using
     capped_distances
 
@@ -23,6 +23,8 @@ def _search_from_capped(ref_ag, config_ag, cutoff):
         Containing the anchor atom to search around (must be a single atom).
     config_ag: MDAnalysis.AtomGroup
         Atoms to include in the search.
+    universe: MDAnalysis.Universe
+        Universe of atomgroups passed (used for box dimensions).
     cutoff: float
         Cutoff search distance value.
 
@@ -37,6 +39,7 @@ def _search_from_capped(ref_ag, config_ag, cutoff):
     pairs, distances = capped_distance(ref_ag.atoms.positions,
                                        config_ag.atoms.positions,
                                        max_cutoff=cutoff,
+                                       box=universe.dimensions,
                                        return_distances=True)
 
     return pairs, distances
@@ -220,6 +223,7 @@ class FindHostAtoms(AnalysisBase):
     def _single_frame(self):
         pairs, distances = _search_from_capped(self.ligand_ag,
                                                self.protein_ag,
+                                               self.atomgroup.universe,
                                                self.search_max_cutoff)
         self._anchor_pairs.append(pairs)
         self._anchor_distances.append(distances)

--- a/MDRestraintsGenerator/tests/test_search.py
+++ b/MDRestraintsGenerator/tests/test_search.py
@@ -152,4 +152,4 @@ def test_search_from_capped_err(u):
     prot = u.atoms
     errmsg = "too many reference atoms passed"
     with pytest.raises(ValueError, match=errmsg):
-        search._search_from_capped(lig, prot, 1.0)
+        search._search_from_capped(lig, prot, u.dimensions, 1.0)


### PR DESCRIPTION
The `_search_capped` function uses MDA's `capped_distance` but wasn't using the box information. This could have caused issues in some cases where we ended up searching for atoms across periodic boundaries. This should fix this.