### PR TITLE
Go for a 0.2.1 bugfix release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ defaults:
     shell: bash -l {0}
 
 env:
-  CONDA_DEPS: "'MDAnalysis' MDAnalysisTests numpy 'scipy<1.8' pytest pytest-cov 'hypothesis<6.2' codecov"
+  CONDA_DEPS: "'MDAnalysis' MDAnalysisTests numpy 'scipy<1.8' pytest pytest-cov codecov"
 
 jobs:
   tests:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,9 +20,11 @@ defaults:
 
 
 jobs:
-  build_wheels:
+  build_wheels_testpypi:
     environment: deploy
-    if: "github.repository == 'IAlibay/MDRestraintsGenerator'"
+    if: |
+      github.repository == 'IAlibay/MDRestraintsGenerator' && 
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package'))
     name: Build pure Python wheel
     runs-on: ubuntu-latest
 
@@ -48,25 +50,52 @@ jobs:
           python -m build --sdist --wheel --outdir dist/
  
       - name: publish_testpypi
-        # Upload to testpypi on every tag
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 
+  build_wheels_pypi:
+    environment: deploy
+    if: |
+      github.repository == 'IAlibay/MDRestraintsGenerator' &&
+      (github.event_name == 'release' && github.event.action == 'published')
+    name: Build pure Python wheel
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: setup_miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.8
+          auto-update-conda: true
+          add-pip-as-python-dependency: true
+          architecture: x64
+
+      - name: install_deps
+        run: |
+          python -m pip install build
+
+      - name: build
+        run: |
+          python -m build --sdist --wheel --outdir dist/
+
       - name: publish_pypi
-        if: github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
   test_testpypi:
     if: |
-      github.repository == 'IAlibay/MDRestraintsGenerator'
+      github.repository == 'IAlibay/MDRestraintsGenerator' &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package'))
     name: testpypi check
     runs-on: ${{ matrix.os }}
-    # needs: build_wheels
+    needs: build_wheels_testpypi
     strategy:
       fail-fast: false
       matrix:
@@ -90,7 +119,7 @@ jobs:
 
       - name: install_test_deps
         run: |
-          pip install pytest pytest-xdist "hypothesis<6.2"
+          pip install pytest pytest-xdist
 
       - name: pip_install
         run: |

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ MDRestraints Generator CHANGELOG
 
 AUTHORS: IAlibay
 
-* 0.3.0 : ??/??/????
+* 0.2.1 : 09/08/2022
 
 Changes
   * Minimum python version is now 3.8, max is 3.10


### PR DESCRIPTION
Because there's a need for an MDA 2+ compliant version, let's go for an immediate release.